### PR TITLE
Implement String :: allNamespacedKeys(array $translations)

### DIFF
--- a/class/Translator/String.php
+++ b/class/Translator/String.php
@@ -40,6 +40,11 @@ class String
         );
     }
 
+    public static function allNamespacedKeys(array $translations)
+    {
+        return self::allNamespacedKeysInContext($translations, array());
+    }
+
     public function __construct($key, $translation, $namespace = null, $description = null)
     {
         $this->key = $key;
@@ -83,6 +88,32 @@ class String
     }
 
 //----------------------------------------------------------------------------------------------------------------------
+
+    private static function allNamespacedKeysInContext($translations, array $currentNamespaceComponents)
+    {
+        $result = array();
+
+        foreach ($translations as $name => $value) {
+            if (is_array($value)) {
+                $result = array_merge(
+                    $result,
+
+                    self::allNamespacedKeysInContext(
+                        $value,
+                        array_merge($currentNamespaceComponents, array($name))
+                    )
+                );
+            }
+            else {
+                $result[] = implode(
+                    ':',
+                    array_filter(array(implode('/', $currentNamespaceComponents), $name))
+                );
+            }
+        }
+
+        return $result;
+    }
 
     private static function keyPart($keyWithNamespace)
     {

--- a/tests/unit/Translator/StringTest.php
+++ b/tests/unit/Translator/StringTest.php
@@ -53,6 +53,34 @@ class StringTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAllNamespacedKeysReturnsNothingForAnEmptyTranslationsArray()
+    {
+        $this->assertEquals(array(), String::allNamespacedKeys(array()));
+    }
+
+    public function testAllNamespacedKeysWorksForFlatTranslationsArray()
+    {
+        $this->assertEquals(
+            array('foo', 'bar'),
+            String::allNamespacedKeys(array('foo' => '1', 'bar' => '2'))
+        );
+    }
+
+    public function testAllNamespacedKeysWorksForDeeplyNestedTranslationsArray()
+    {
+        $this->assertEquals(
+            array('foo/bar/fiz/buz:moo', 'goo', 'doo:zoo'),
+
+            String::allNamespacedKeys(
+                array(
+                    'foo' => array('bar' => array('fiz' => array('buz' => array('moo' => 'Му')))),
+                    'goo' => 'Гу',
+                    'doo' => array('zoo' => 'Зу')
+                )
+            )
+        );
+    }
+
     public function testSupportsDescription()
     {
         $this->assertEquals(


### PR DESCRIPTION
To use in registerReferenceTranslationKeysIfTheyAreMissing()
