### PR TITLE
Fixed that issue when namespace is deeper than available.

### DIFF
--- a/class/Translator/String.php
+++ b/class/Translator/String.php
@@ -137,10 +137,10 @@ class String
     {
         $readFrom = $array;
         foreach (array_filter(explode('/', $namespace)) as $ns) {
-            if (array_key_exists($ns, $readFrom)) {
+            if (array_key_exists($ns, $readFrom) && is_array($readFrom[$ns])) {
                 $readFrom = $readFrom[$ns];
             } else {
-                break;
+                return null;
             }
         }
         $translation = array_key_exists($key, $readFrom) ? $readFrom[$key] : null;

--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,14 @@
             "name": "Maxim Gnatenko",
             "email": "maxim@xiag.ch"
         },
-
         {
             "name": "Ivan Krechetov",
             "email": "ivan.krechetov@gmail.com"
+        },
+        {
+            "name": "Anton Bondar",
+            "email": "anton@zebooka.com"
         }
-
     ],
     "autoload": {
         "psr-0": {

--- a/tests/unit/Translator/StringTest.php
+++ b/tests/unit/Translator/StringTest.php
@@ -53,6 +53,38 @@ class StringTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDefaultTranslationIfCanNotBeFoundInHierarchicalArrayIfNSLonger()
+    {
+        $this->assertEquals(
+            String::create('validation/error/fatal:notQuiteSimpleKeyToSearch', 'Not quite simple key to search'),
+            String::find(
+                'validation/error/fatal:notQuiteSimpleKeyToSearch',
+                array(
+                    'validation' => array(
+                        'error' => array(
+                            'notQuiteSimpleKeyToSearch' => 'Should be not empty'
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    public function testDefaultTranslationIfCanNotBeFoundInHierarchicalArrayIfKeyExistsSimilarToNS()
+    {
+        $this->assertEquals(
+            String::create('validation/error:notQuiteSimpleKeyToSearch', 'Not quite simple key to search'),
+            String::find(
+                'validation/error:notQuiteSimpleKeyToSearch',
+                array(
+                    'validation' => array(
+                        'error' => 'This is an error'
+                    )
+                )
+            )
+        );
+    }
+
     public function testAllNamespacedKeysReturnsNothingForAnEmptyTranslationsArray()
     {
         $this->assertEquals(array(), String::allNamespacedKeys(array()));


### PR DESCRIPTION
Fixed issue with finding wrong translation or throwing warning instead of creating default translation in two special cases:
1) When namespace is deeper than avaiable, but there is same key in available shorter namespace.
2) When there is a key with same name as namespace last part.
