### PR TITLE
Emit empty namespace in all_namespaces view, because we always have it (...

### DIFF
--- a/class/Translator/Storage/CouchDb/Schema.php
+++ b/class/Translator/Storage/CouchDb/Schema.php
@@ -144,6 +144,7 @@ function (doc) {
             combinedNs = combinedNs + '/'
         }
     }
+    emit('', null);
 }
 CouchJS;
 


### PR DESCRIPTION
...it has all documents).
