### PR TITLE
Changes to bulk couchdb storage implementation

### DIFF
--- a/class/Translator/Storage/CouchDb/Bulk.php
+++ b/class/Translator/Storage/CouchDb/Bulk.php
@@ -44,7 +44,11 @@ class Bulk extends CouchDb
 
                 /** @var String $string */
                 foreach ($this->stringsStack[$behavior] as $string) {
-                    $bulkUpdater->updateDocument($this->createDocument($string, $behavior, $existingStrings));
+                    $existingStrings[$string->hash()] = $this->createDocument($string, $behavior, $existingStrings);
+                }
+
+                foreach ($existingStrings as $document) {
+                    $bulkUpdater->updateDocument($document);
                 }
 
                 $bulkUpdater->execute();


### PR DESCRIPTION
Fixed bug where there could be several copies of one string, made some memory usage optimizations.
